### PR TITLE
line 26 cmd

### DIFF
--- a/tester.py
+++ b/tester.py
@@ -23,7 +23,7 @@ for mapNo in range(10):
 			ruleDir = "testcases/rules/rules"+str(ruleNo+1)+".txt"
 
 
-			cmd = "python the3.py " + mapDir + " " + ruleDir + " " + str(genNo); 
+			cmd = "python2 the3.py " + mapDir + " " + ruleDir + " " + str(genNo); 
 			stream = os.popen(cmd)
 			output = stream.read()
 


### PR DESCRIPTION
line26'da 
cmd = "pyhton the3.py ..." yerine cmd = "pyhton2 the3.py ..." yapıldı,
çünkü default olarak python3.6 kullanan sistemlerde hata veriyor.